### PR TITLE
Jkranz rk/issue18 (#19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NOTE ABOUT THE TEST DIRECTORY: the "test" directory is _not_ needed for sandbox 
 
 ## Latest Released Unlocked Package Install URL
 
-`/packaging/installPackage.apexp?p0=04t4x000000RUUUAA4`
+`/packaging/installPackage.apexp?p0=04t4x000000RqyHAAS`
 
 ## Display Types 
 

--- a/config/project-scratch-installtesting.json
+++ b/config/project-scratch-installtesting.json
@@ -1,0 +1,5 @@
+{
+    "orgName": "RecordType Picker Install Testing",
+    "edition": "Enterprise",
+    "features": []
+  }

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "path": "src",
             "default": true,
             "package": "Record Type Picker",
-            "versionName": "ver 0.1",
-            "versionNumber": "0.1.0.NEXT",
+            "versionName": "ver 0.3",
+            "versionNumber": "0.3.0.NEXT",
             "unpackagedMetadata": {
                 "path": "tests"
             },
@@ -13,14 +13,16 @@
                 "permissionSets": [
                     "RecordTypePickerPermissionsTesting"
                 ]
-            }
+            },
+            "releaseNotesUrl": "https://github.com/jkranz-rk/RecordTypePicker",
+            "postInstallUrl": "https://github.com/jkranz-rk/RecordTypePicker"
         },
         {
             "path": "tests"
         }
     ],
     "name": "RecordTypePicker",
-    "namespace": "",
+    "namespace": "rtp",
     "sfdcLoginUrl": "https://login.salesforce.com",
     "sourceApiVersion": "55.0",
     "packageAliases": {
@@ -28,6 +30,10 @@
         "Record Type Picker@0.1.0-1-feature/unlockedpackaging": "04t4x000000RUQ2AAO",
         "Record Type Picker@0.1.0-2-feature/unlockedpackaging": "04t4x000000RUQ7AAO",
         "Record Type Picker@0.1.0-3-feature/unlockedpackaging": "04t4x000000RUQCAA4",
-        "Record Type Picker@0.1.0-2": "04t4x000000RUUUAA4"
+        "Record Type Picker@0.1.0-2": "04t4x000000RUUUAA4",
+        "Record Type Picker@0.2.0-2": "04t4x000000RqffAAC",
+        "Record Type Picker@0.2.0-3": "04t4x000000RqfkAAC",
+        "Record Type Picker@0.2.0-4": "04t4x000000RqyCAAS",
+        "Record Type Picker@0.3.0-1": "04t4x000000RqyHAAS"
     }
 }

--- a/src/main/default/classes/RecordTypePickerController.cls
+++ b/src/main/default/classes/RecordTypePickerController.cls
@@ -40,6 +40,8 @@ global with sharing class RecordTypePickerController {
     @InvocableMethod(
         label='Record Types for Running User'
         description='Input an Object\'s API name, returns a collection of Record Types that are available to the running user'
+        category='Record Types'
+        iconName='slds:standard:relationship'
     )
     /**
      */

--- a/src/main/default/lwc/cpeHelper/cpeHelper.js
+++ b/src/main/default/lwc/cpeHelper/cpeHelper.js
@@ -33,6 +33,20 @@ const flowConstants = {
     }
 };
 
+const convertBooleanFlowToReal = (boolVal) => {
+    if (boolVal === '$GlobalConstant.True') {
+        return true;
+    } else if (boolVal === '$GlobalConstant.False') {
+        return false;
+    } else {
+        return boolVal;
+    }
+};
+
+const convertBooleanRealToFlow = (boolVal) => {
+    return boolVal ? '$GlobalConstant.True' : '$GlobalConstant.False';
+};
+
 const defaultProperties = {
     objectApiName : {
         name : 'objectApiName',
@@ -49,9 +63,9 @@ const defaultProperties = {
         value : 'picker',
         valueDataType : 'String'
     },
-    showDescription : {
-        name : 'showDescription',
-        value : true,
+    hideDescriptions : {
+        name : 'hideDescriptions',
+        value : false,
         valueDataType : 'Boolean'
     },
     autoNavigateNext : {
@@ -61,4 +75,4 @@ const defaultProperties = {
     }
 };
 
-export {notifyPropertyChange, flowConstants, defaultProperties};
+export {notifyPropertyChange, flowConstants, defaultProperties, convertBooleanFlowToReal, convertBooleanRealToFlow};

--- a/src/main/default/lwc/recordTypePicker/recordTypePicker.js
+++ b/src/main/default/lwc/recordTypePicker/recordTypePicker.js
@@ -15,16 +15,17 @@ export default class RecordTypePicker extends LightningElement {
     @api availableRecordTypes;
 
     @api objectApiName;
-    @api label;
+
+    @api
     get label(){
         return this._label;
     }
     set label(val){
         this._label = val;
     }
-    _label = 'Select a RecordType';
+    _label = 'Select a Record Type';
 
-    @api autoNavigateNext;
+    @api
     get autoNavigateNext(){
         return this._autoNavigateNext;
     }
@@ -33,16 +34,16 @@ export default class RecordTypePicker extends LightningElement {
     }
     _autoNavigateNext = false;
 
-    @api showDescription;
-    get showDescription(){
-        return this._showDescription;
+    @api
+    get hideDescriptions(){
+        return this._hideDescriptions;
     }
-    set showDescription(val){
-        this._showDescription = val;
+    set hideDescriptions(val){
+        this._hideDescriptions = val;
     }
-    _showDescription = true;
+    _hideDescriptions;
 
-    @api displayType;
+    @api
     get displayType(){
         return this._displayType;
     }
@@ -51,7 +52,7 @@ export default class RecordTypePicker extends LightningElement {
     }
     _displayType = 'picker';
 
-    @api mode;
+    @api
     get mode(){
         return this._mode;
     }
@@ -59,6 +60,10 @@ export default class RecordTypePicker extends LightningElement {
         this._mode = val?.toLowerCase();
     }
     _mode = 'live';
+
+    // deprecated in favor of hideDescriptions, since we want the default
+    // value to be `True`, its a bad practice to set boolean defaults to `True`
+    @api showDescription; 
 
     _error;
     _selectedValue;
@@ -108,7 +113,7 @@ export default class RecordTypePicker extends LightningElement {
     };
 
     get picklistOptions(){
-        if (this.showDescription){
+        if (!this.hideDescriptions){
             return this.availableRecordTypes.map((rt) => {
                 return {
                     value: rt.Id,
@@ -124,7 +129,6 @@ export default class RecordTypePicker extends LightningElement {
                 };
             });
         }
-        
     }
 
     handleChange(event){

--- a/src/main/default/lwc/recordTypePicker/recordTypePicker.js-meta.xml
+++ b/src/main/default/lwc/recordTypePicker/recordTypePicker.js-meta.xml
@@ -10,7 +10,7 @@
     <targetConfigs>
         <targetConfig 
             targets="lightning__FlowScreen"
-            configurationEditor="rtp-record-type-picker-cpe">
+            configurationEditor="rtp-record-type-picker-cpe"> 
             <property 
                 name="objectApiName" 
                 type="String" 
@@ -23,7 +23,7 @@
                 type="String" 
                 label="Label" 
                 description="Label to display above the selection. Defaults to 'Select a Record Type'" 
-                default="Select a RecordType"
+                default="Select a Record Type"
                 role="inputOnly"
                 />
             <property 
@@ -41,11 +41,11 @@
                 role="inputOnly"
                 />
             <property
-                name="showDescription"
+                name="hideDescriptions"
                 type="Boolean"
-                label="Show Descriptions"
-                description="Set to TRUE to display each Record Type's Description" 
-                default="true"
+                label="Hide Descriptions"
+                description="Set to TRUE to hide the Record Types' Descriptions" 
+                default="false"
                 role="inputOnly"
                 />
             <property 
@@ -54,6 +54,14 @@
                 label="Display Type" 
                 default="picker" 
                 description="Choose how to display the Record Type Picker: picker, radio, or picklist. Defaults to picker" 
+                role="inputOnly"
+                />
+            <property 
+                name="showDescription" 
+                type="Boolean" 
+                label="DEPRECATED"
+                description="DEPRECATED"
+                default="true"
                 role="inputOnly"
                 />
         </targetConfig>

--- a/src/main/default/lwc/recordTypePicker/recordTypeRadioGroup.html
+++ b/src/main/default/lwc/recordTypePicker/recordTypeRadioGroup.html
@@ -9,7 +9,7 @@
                         <label class="slds-radio__label slds-grid" for={recordType.Id}>
                             <span class="slds-radio_faux slds-m-top_xxx-small"></span>
                             <span class="slds-form-element__label slds-p-top_none">
-                                <template if:true={showDescription}>
+                                <template if:false={hideDescriptions}>
                                     <lightning-layout multiple-rows class="slds-m-bottom_x-small">
                                         <lightning-layout-item size="12" flexibility="auto" class="slds-p-left_none">
                                             <strong>{recordType.Name}</strong>
@@ -19,7 +19,7 @@
                                         </lightning-layout-item>
                                     </lightning-layout>
                                 </template>
-                                <template if:false={showDescription}>
+                                <template if:true={hideDescriptions}>
                                     {recordType.Name}
                                 </template>
                             </span>

--- a/src/main/default/lwc/recordTypePicker/recordTypeVisualPicker.html
+++ b/src/main/default/lwc/recordTypePicker/recordTypeVisualPicker.html
@@ -22,7 +22,7 @@
                                     <span class="slds-text-heading_medium slds-m-bottom_x-small">
                                         {recordType.Name}
                                     </span>
-                                    <span if:true={showDescription} class="slds-text-title">
+                                    <span if:false={hideDescriptions} class="slds-text-title">
                                         {recordType.Description}
                                     </span>
                                 </span>

--- a/src/main/default/lwc/recordTypePickerCpe/recordTypePickerCpe.html
+++ b/src/main/default/lwc/recordTypePickerCpe/recordTypePickerCpe.html
@@ -31,7 +31,7 @@
                                     object-api-name={previewConfig.objectApiName.value}
                                     mode="preview"
                                     class="preview"
-                                    show-description={previewConfig.showDescription.value} >
+                                    hide-descriptions={previewConfig.hideDescriptions.value} >
                                 </c-record-type-picker> 
                             </template>
                         </div>

--- a/src/main/default/lwc/recordTypePickerCpeInputs/recordTypePickerCpeInputs.html
+++ b/src/main/default/lwc/recordTypePickerCpeInputs/recordTypePickerCpeInputs.html
@@ -32,7 +32,7 @@
             type="toggle" 
             label="Show Record Type Descriptions" 
             class="slds-m-top_xx-small"
-            data-attribute="showDescription"
+            data-attribute="hideDescriptions"
             data-type="Boolean"
             onchange={handleBooleanChange}
             checked={showDescription}>
@@ -43,8 +43,7 @@
             data-attribute="autoNavigateNext"
             data-type="Boolean"
             onchange={handleBooleanChange}
-            checked={autoNavigateNext}
-        >
+            checked={autoNavigateNext}>
         </lightning-input>
     </template>
     <template if:true={_error}>

--- a/src/main/default/lwc/recordTypePickerCpeInputs/recordTypePickerCpeInputs.js
+++ b/src/main/default/lwc/recordTypePickerCpeInputs/recordTypePickerCpeInputs.js
@@ -40,11 +40,15 @@ export default class RecordTypePickerCpeInputs extends LightningElement {
         return this._config?.displayType.value ?? defaultProperties.displayType.value;
     };
     get showDescription() {
-        return this._config?.showDescription.value ?? defaultProperties.showDescription.value;
+        return (this._config?.hideDescriptions.value ?? defaultProperties.hideDescriptions.value) === false;
     };
     get autoNavigateNext(){
         return this._config?.autoNavigateNext.value ?? defaultProperties.autoNavigateNext.value;
     };
+
+    get variant(){
+        return this.showDescription ? 'brand' : 'neutral';
+    }
 
     connectedCallback(){
         getObjectsWithRecordTypes().then((data) => {
@@ -72,7 +76,7 @@ export default class RecordTypePickerCpeInputs extends LightningElement {
     handleBooleanChange(event){
         this.publishChange({
             name: event.target.dataset.attribute,
-            newValue: event.target.checked,
+            newValue: (event.target.dataset.attribute === 'hideDescriptions') ? !event.target.checked : event.target.checked,
             newValueDataType: 'Boolean'
         });
     };
@@ -82,5 +86,6 @@ export default class RecordTypePickerCpeInputs extends LightningElement {
             { detail: {...values} }
         );
         this.dispatchEvent(valueChangeEvent);
+        this._config[values.name] = {...values};
     };
 }


### PR DESCRIPTION
* Setting "Show Description" toggle  to False in CPE doesn't save attribute to Flow Properties Fixes #18

See discussion on issue.
Flow Builder Runtime will send Strings instead
of Boolean values to CPE, so this update transforms those strings to Booleans, and then back again.

Also changed the approach, using "hideDescription" with a default of False instead of "showDescription" with a default
of True. Bad practice to use true as default
for Element attributes, so flipped that.

This is an "under the hood" change, as
CPE UI still presents as "Show Description"
because from the User perspective, it feels
more natural to be active when you are showing
the descriptions, and then toggle off to hide

* Added an icon. Pretty!

* Created a separate scratch org def file for spinning up a test install during package testing

* bump to v0.3!