### PR TITLE
Version 0.4 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ NOTE ABOUT THE TEST DIRECTORY: the "test" directory is _not_ needed for sandbox 
 
 ## Latest Released Unlocked Package Install URL
 
-`/packaging/installPackage.apexp?p0=04t4x000000RqyHAAS`
+`/packaging/installPackage.apexp?p0=04t4x000000Rr3MAAS`
 
 ## Display Types 
 

--- a/sfdx-project.json
+++ b/sfdx-project.json
@@ -4,8 +4,8 @@
             "path": "src",
             "default": true,
             "package": "Record Type Picker",
-            "versionName": "ver 0.3",
-            "versionNumber": "0.3.0.NEXT",
+            "versionName": "ver 0.4",
+            "versionNumber": "0.4.0.NEXT",
             "unpackagedMetadata": {
                 "path": "tests"
             },
@@ -24,7 +24,7 @@
     "name": "RecordTypePicker",
     "namespace": "rtp",
     "sfdcLoginUrl": "https://login.salesforce.com",
-    "sourceApiVersion": "55.0",
+    "sourceApiVersion": "56.0",
     "packageAliases": {
         "Record Type Picker": "0Ho4x000000GmwBCAS",
         "Record Type Picker@0.1.0-1-feature/unlockedpackaging": "04t4x000000RUQ2AAO",
@@ -34,6 +34,8 @@
         "Record Type Picker@0.2.0-2": "04t4x000000RqffAAC",
         "Record Type Picker@0.2.0-3": "04t4x000000RqfkAAC",
         "Record Type Picker@0.2.0-4": "04t4x000000RqyCAAS",
-        "Record Type Picker@0.3.0-1": "04t4x000000RqyHAAS"
+        "Record Type Picker@0.3.0-1": "04t4x000000RqyHAAS",
+        "Record Type Picker@0.3.0-2": "04t4x000000Rr1BAAS",
+        "Record Type Picker@0.4.0": "04t4x000000Rr3MAAS"
     }
 }

--- a/src/main/default/classes/RecordTypePickerController.cls
+++ b/src/main/default/classes/RecordTypePickerController.cls
@@ -43,8 +43,6 @@ global with sharing class RecordTypePickerController {
         category='Record Types'
         iconName='slds:standard:relationship'
     )
-    /**
-     */
     global static List<RecordTypePickerController.Result> invokeGetRecordTypes(List<RecordTypePickerController.Request> requests) {
         Set<String> objectNameSet = new Set<String>();
         Set<Id> availableRecordTypeIds = new Set<Id>();
@@ -53,7 +51,6 @@ global with sharing class RecordTypePickerController {
         for (RecordTypePickerController.Request request : requests) {
             objectNameSet.add(request.objectApiName);
         }
-
 
         availableRecordTypeIds.addAll(
             RecordTypePickerController.availableRecordTypeIdsFromObjectApiNames(new List<String>( objectNameSet ))
@@ -77,14 +74,14 @@ global with sharing class RecordTypePickerController {
             label='Object API Name'
             required=true
         )
-        public String objectApiName;
+        global String objectApiName;
     }
 
     global class Result {
         @InvocableVariable(
             label='Record Types for Running User'
         )
-        public List<RecordType> recordTypes;
+        global List<RecordType> recordTypes;
     }
 
     /**

--- a/src/main/default/classes/RecordTypePickerController.cls-meta.xml
+++ b/src/main/default/classes/RecordTypePickerController.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/main/default/lwc/configurationModal/configurationModal.js-meta.xml
+++ b/src/main/default/lwc/configurationModal/configurationModal.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/src/main/default/lwc/cpeHelper/cpeHelper.js-meta.xml
+++ b/src/main/default/lwc/cpeHelper/cpeHelper.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/src/main/default/lwc/recordTypePicker/recordTypePicker.js-meta.xml
+++ b/src/main/default/lwc/recordTypePicker/recordTypePicker.js-meta.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>true</isExposed>
     <masterLabel>Record Type Picker</masterLabel>
     <description>Display a record type selection on a screen</description>

--- a/src/main/default/lwc/recordTypePickerCpe/recordTypePickerCpe.js-meta.xml
+++ b/src/main/default/lwc/recordTypePickerCpe/recordTypePickerCpe.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/src/main/default/lwc/recordTypePickerCpeInputs/recordTypePickerCpeInputs.js-meta.xml
+++ b/src/main/default/lwc/recordTypePickerCpeInputs/recordTypePickerCpeInputs.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/src/main/default/lwc/recordTypePickerLwcUtils/recordTypePickerLwcUtils.js-meta.xml
+++ b/src/main/default/lwc/recordTypePickerLwcUtils/recordTypePickerLwcUtils.js-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <isExposed>false</isExposed>
 </LightningComponentBundle>

--- a/tests/main/default/classes/RecordTypePickerControllerTest.cls-meta.xml
+++ b/tests/main/default/classes/RecordTypePickerControllerTest.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>55.0</apiVersion>
+    <apiVersion>56.0</apiVersion>
     <status>Active</status>
 </ApexClass>


### PR DESCRIPTION
# Version 0.4 Release: Bug Fix and Winter 23 v56.0 API bumps

* Invocable action's inputs and outputs not appearing in Flow Builder in Subscriber orgs Fixes #22 

> The inner class InvocableVariables were marked as Public and not Global. How on earth I didn't catch this sooner, I do not know. Being able to reference the default namespace in unpackaged metadata during package creation would have caught this however. So, for that reason: I can blame Salesforce instead of myself 😅

* Bump API versions from 55.0 to 56.0

* Package Version 0.4 Promoted to Released

* Update Package Install URL to version 0.4